### PR TITLE
Compiled on Ubuntu 22.04/RTX3090 with Optix 7.4.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,7 +381,7 @@ endfunction()
 #add_subdirectory( eyeGenerator )
 add_subdirectory( libEyeRenderer3 )
 
-#add_subdirectory( newGuiEyeRenderer )
+add_subdirectory( newGuiEyeRenderer )
 
 # NVidia's sutil library.  The rules to build it are found in the subdirectory.
 add_subdirectory(sutil)

--- a/docs/indepth-install-notes.md
+++ b/docs/indepth-install-notes.md
@@ -18,11 +18,11 @@ However, the versions used in this install (Ubuntu 20.04.3 LTS, Nvidia driver 47
 
 **Tested Environment Variations**
 
-Tested Ubuntu versions: 20.04.03, 20.04.02<br>
-Tested Graphics Cards: GTX 1080Ti, GTX 1060, RTX 2080Ti, GeForce GT 1030<br>
-Tested Driver versions: 470, 495<br>
+Tested Ubuntu versions: 20.04.03, 20.04.02, 22.04.02<br>
+Tested Graphics Cards: GTX 1080Ti, GTX 1060, RTX 2080Ti, GeForce GT 10, RTX 3090<br>
+Tested Driver versions: 470, 495, 515<br>
 Tested CUDA versions: 11.5, 11.4<br>
-Tested OptiX SDK versions: 7.3.0, 7.2.0<br>
+Tested OptiX SDK versions: 7.4.0 7.3.0, 7.2.0<br>
 
 Feel free to add your own configuration information to these lists via pull request to help others!
 
@@ -44,7 +44,7 @@ $ sudo add-apt-repository universe
 
 The Nvidia Optix SDK requires a number of dependencies to be installed beforehand, this should be installable by running
 ```
-$ sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev 
+$ sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev
 ```
 
 To get a copy of CompoundRay, git should be installed on the machine. This is accessible via:
@@ -300,4 +300,3 @@ The table below shows some information about the difference options available an
 | GL_INTEROP | Single device only, preferred for single device use. |
 | ZERO_COPY | The most general use-case, preferred for multi-gpu systems if not fully nvlink connected. |
 | CUDA_P2P | Only to be used in fully nvlink connected envrionments. |
-

--- a/libEyeRenderer3/MulticamScene.cpp
+++ b/libEyeRenderer3/MulticamScene.cpp
@@ -25,7 +25,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-//        This file was originally based on the "Scene.cpp" file 
+//        This file was originally based on the "Scene.cpp" file
 //        that comes within sutil of the NVidia OptiX SDK, but has
 //        been changed by Blayze Millward to be more aligned to the
 //        design schema of the insect eye perspective renderer.
@@ -291,7 +291,7 @@ void processGLTFNode(
           scene.addCamera(camera);
           camera->copyOmmatidia(ommVector.data());
           scene.addCompoundCamera(camera);
-          
+
           eyeDataFile.close();
 
           return;
@@ -1306,7 +1306,7 @@ void MulticamScene::createPTXModule()
 
     OptixModuleCompileOptions module_compile_options = {};
     module_compile_options.optLevel   = OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-    module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_LINEINFO;
+    module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
 
     m_pipeline_compile_options = {};
     m_pipeline_compile_options.usesMotionBlur            = false;
@@ -1688,4 +1688,3 @@ float3 MulticamScene::getGeometryMinBounds(std::string name)
 
   return make_float3(0.0f);
 }
-

--- a/sutil/Scene.cpp
+++ b/sutil/Scene.cpp
@@ -1066,7 +1066,7 @@ void Scene::createPTXModule()
 
     OptixModuleCompileOptions module_compile_options = {};
     module_compile_options.optLevel   = OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
-    module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_LINEINFO;
+    module_compile_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_MINIMAL;
 
     m_pipeline_compile_options = {};
     m_pipeline_compile_options.usesMotionBlur            = false;


### PR DESCRIPTION
I compiled on Ubuntu 22.04 with the Ubuntu-installed NVidia driver
version 515.105.01 and CUDA version 11.5.1. For example, here is the
cuda-dev package that was installed:

nvidia-cuda-dev/jammy,now 11.5.1-1ubuntu1 amd64 [installed,automatic]

Used a RTX3090 GPU.

Note that I had to uncomment a line in the CMakeLists.txt to get the
Gui test to work.

I've not yet explored the Python bindings (can't stand Python! Can't I
do everything in C++?)

Anyhow, tests work, build was essentially painless. Nice job Blaize.